### PR TITLE
color tile tiny 버전 사이즈 조정

### DIFF
--- a/components/chips/Chip.style.ts
+++ b/components/chips/Chip.style.ts
@@ -18,7 +18,7 @@ type ChipStyleProps = {
 export const BasicChip = styled.span<ChipStyleProps>`
   display: inline-flex;
   align-items: center;
-  
+
   padding: 2px 6px;
   height: ${({ $size }) => ($size === 'large' ? 22 : 20)}px;
 
@@ -48,7 +48,7 @@ const colorPaletteList = {
 const colorTileSizeList = {
   large: 30,
   small: 28,
-  tiny: 8,
+  tiny: 6,
 };
 
 export const ColorPalette = styled.div`


### PR DESCRIPTION
## What is the PR? 🔍

<!-- 아래 리스트를 지우고, 작업하게 된 배경을 적어주세요. -->

- color tile tiny 버전이 너무 큼

## Changes 📝

<!-- 작업 내용 및 덧붙이고 싶은 내용이 있다면! -->
- 8px -> 6px 로 사이즈 조정

## Related Issues 💭

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 수고했습니다~* -->

- Resolved: #
